### PR TITLE
update to AWS SDK 2.10.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ libraries.internal = [
 // in the uberjar; the caller must provide them on the classpath at runtime.
 libraries.external = [
     "com.launchdarkly:launchdarkly-java-server-sdk:4.6.4",
-    "software.amazon.awssdk:dynamodb:2.1.4",
+    "software.amazon.awssdk:dynamodb:2.10.32",
     "org.slf4j:slf4j-api:1.7.21"
 ]
 


### PR DESCRIPTION
We don't bundle the DynamoDB client code in our jars, but there is still a compile-time dependency and the current versions have some warnings:

https://github.com/aws/aws-sdk-java-v2/issues/1403

Per [this explanation](https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062) it seems unlikely that there would have been any real consequences to this, since we do not use polymorphic typing.