### PR TITLE
use newer API for Java SDK 4.12.0 and above

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ libraries.internal = [
 // global state that must be shared between the SDK and the caller. These are not embedded
 // in the uberjar; the caller must provide them on the classpath at runtime.
 libraries.external = [
-    "com.launchdarkly:launchdarkly-java-server-sdk:4.6.4",
+    "com.launchdarkly:launchdarkly-java-server-sdk:4.12.0-SNAPSHOT",
     "software.amazon.awssdk:dynamodb:2.10.32",
     "org.slf4j:slf4j-api:1.7.21"
 ]
@@ -54,7 +54,7 @@ libraries.test = [
     "org.hamcrest:hamcrest-all:1.3",
     "junit:junit:4.12",
     "ch.qos.logback:logback-classic:1.1.7",
-    "com.launchdarkly:launchdarkly-java-server-sdk:4.6.4:test" // our unit tests use helper classes from the SDK
+    "com.launchdarkly:launchdarkly-java-server-sdk:4.12.0-SNAPSHOT:test" // our unit tests use helper classes from the SDK
 ]
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ libraries.internal = [
 // global state that must be shared between the SDK and the caller. These are not embedded
 // in the uberjar; the caller must provide them on the classpath at runtime.
 libraries.external = [
-    "com.launchdarkly:launchdarkly-java-server-sdk:4.12.0-SNAPSHOT",
+    "com.launchdarkly:launchdarkly-java-server-sdk:4.12.0",
     "software.amazon.awssdk:dynamodb:2.10.32",
     "org.slf4j:slf4j-api:1.7.21"
 ]
@@ -54,7 +54,7 @@ libraries.test = [
     "org.hamcrest:hamcrest-all:1.3",
     "junit:junit:4.12",
     "ch.qos.logback:logback-classic:1.1.7",
-    "com.launchdarkly:launchdarkly-java-server-sdk:4.12.0-SNAPSHOT:test" // our unit tests use helper classes from the SDK
+    "com.launchdarkly:launchdarkly-java-server-sdk:4.12.0:test" // our unit tests use helper classes from the SDK
 ]
 
 dependencies {

--- a/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbComponents.java
+++ b/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbComponents.java
@@ -16,7 +16,7 @@ public abstract class DynamoDbComponents {
    * @param tableName The table name in DynamoDB. This table must already exist (see package
    * documentation).
    * @return the builder
-   * @deprecated Use {@link com.launchdarkly.client.integrations.DynamoDb#dataStore()}
+   * @deprecated Use {@link com.launchdarkly.client.integrations.DynamoDb#dataStore(String)}
    */
   @Deprecated
   public static DynamoDbFeatureStoreBuilder dynamoDbFeatureStore(String tableName) {

--- a/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbComponents.java
+++ b/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbComponents.java
@@ -1,8 +1,12 @@
 package com.launchdarkly.client.dynamodb;
 
 /**
- * Entry point for using the DynamoDB feature store.
+ * Deprecated entry point for the DynamoDB data store. This is for use with the older feature store API
+ * in Java SDK 4.11.x and below. For Java SDK 4.12 and above, use {@link com.launchdarkly.client.integrations.DynamoDb}.
+ * 
+ * @deprecated Use {@link com.launchdarkly.client.integrations.DynamoDb}.
  */
+@Deprecated
 public abstract class DynamoDbComponents {
   /**
    * Creates a builder for a DynamoDB feature store. You can modify any of the store's properties with
@@ -12,7 +16,9 @@ public abstract class DynamoDbComponents {
    * @param tableName The table name in DynamoDB. This table must already exist (see package
    * documentation).
    * @return the builder
+   * @deprecated Use {@link com.launchdarkly.client.integrations.DynamoDb#dataStore()}
    */
+  @Deprecated
   public static DynamoDbFeatureStoreBuilder dynamoDbFeatureStore(String tableName) {
     return new DynamoDbFeatureStoreBuilder(tableName);
   }

--- a/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbFeatureStoreBuilder.java
+++ b/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbFeatureStoreBuilder.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
  * This class is retained for backward compatibility with older Java SDK versions and will be removed in a
  * future version. 
  * 
- * @deprecated Use {@link com.launchdarkly.client.integrations.DynamoDb#dataStore()}
+ * @deprecated Use {@link com.launchdarkly.client.integrations.DynamoDb#dataStore(String)}
  */
 @Deprecated
 public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory, DiagnosticDescription {

--- a/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbFeatureStoreBuilder.java
+++ b/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbFeatureStoreBuilder.java
@@ -1,9 +1,14 @@
 package com.launchdarkly.client.dynamodb;
 
+import com.launchdarkly.client.Components;
 import com.launchdarkly.client.FeatureStore;
 import com.launchdarkly.client.FeatureStoreCacheConfig;
 import com.launchdarkly.client.FeatureStoreFactory;
-import com.launchdarkly.client.utils.CachingStoreWrapper;
+import com.launchdarkly.client.LDConfig;
+import com.launchdarkly.client.integrations.DynamoDbDataStoreBuilder;
+import com.launchdarkly.client.integrations.PersistentDataStoreBuilder;
+import com.launchdarkly.client.interfaces.DiagnosticDescription;
+import com.launchdarkly.client.value.LDValue;
 
 import java.net.URI;
 
@@ -11,40 +16,29 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 
 /**
- * Builder/factory class for the DynamoDB feature store.
+ * Deprecated builder class for the Redis-based persistent data store.
  * <p>
- * Create this builder by calling {@link DynamoDbComponents#dynamoDbFeatureStore(String)}, then
- * optionally modify its properties with builder methods, and then include it in your client
- * configuration with {@link com.launchdarkly.client.LDConfig.Builder#featureStoreFactory(FeatureStoreFactory)}.
- * <p>
- * The AWS SDK provides many configuration options for a DynamoDB client. This class has
- * corresponding methods for some of the most commonly used ones. If you need more sophisticated
- * control over the DynamoDB client, you can construct one of your own and pass it in with the
- * {@link #existingClient(DynamoDbClient)} method.
+ * The replacement for this class is {@link com.launchdarkly.client.integrations.DynamoDb}.
+ * This class is retained for backward compatibility with older Java SDK versions and will be removed in a
+ * future version. 
+ * 
+ * @deprecated Use {@link com.launchdarkly.client.integrations.DynamoDb#dataStore()}
  */
-public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory {
-  private final String tableName;
-  
-  private String prefix;
-  private DynamoDbClient existingClient;
-  private DynamoDbClientBuilder clientBuilder;
-  
-  private FeatureStoreCacheConfig caching = FeatureStoreCacheConfig.DEFAULT;
+@Deprecated
+public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory, DiagnosticDescription {
+  private final PersistentDataStoreBuilder wrappedOuterBuilder;
+  private final DynamoDbDataStoreBuilder wrappedBuilder;
   
   DynamoDbFeatureStoreBuilder(String tableName) {
-    this.tableName = tableName;
-    clientBuilder = DynamoDbClient.builder();
+    wrappedBuilder = com.launchdarkly.client.integrations.DynamoDb.dataStore(tableName);
+    wrappedOuterBuilder = Components.persistentDataStore(wrappedBuilder);
   }
   
   @Override
-  public FeatureStore createFeatureStore() {  
-    DynamoDbClient client = (existingClient != null) ? existingClient : clientBuilder.build();
-    DynamoDbFeatureStoreCore core = new DynamoDbFeatureStoreCore(client, tableName, prefix);
-    CachingStoreWrapper wrapper = CachingStoreWrapper.builder(core).caching(caching).build();
-    return wrapper;
+  public FeatureStore createFeatureStore() {
+    return wrappedOuterBuilder.createFeatureStore();
   }
   
   /**
@@ -54,7 +48,7 @@ public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory {
    * @return the builder
    */
   public DynamoDbFeatureStoreBuilder clientOverrideConfiguration(ClientOverrideConfiguration config) {
-    clientBuilder.overrideConfiguration(config);
+    wrappedBuilder.clientOverrideConfiguration(config);
     return this;
   }
   
@@ -66,7 +60,7 @@ public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory {
    * @return the builder
    */
   public DynamoDbFeatureStoreBuilder credentials(AwsCredentialsProvider credentialsProvider) {
-    clientBuilder.credentialsProvider(credentialsProvider);
+    wrappedBuilder.credentials(credentialsProvider);
     return this;
   }
   
@@ -79,7 +73,7 @@ public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory {
    * @return the builder
    */
   public DynamoDbFeatureStoreBuilder endpoint(URI endpointUri) {
-    clientBuilder.endpointOverride(endpointUri);
+    wrappedBuilder.endpoint(endpointUri);
     return this;
   }
   
@@ -91,7 +85,7 @@ public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory {
    * @return the builder
    */
   public DynamoDbFeatureStoreBuilder region(Region region) {
-    clientBuilder.region(region);
+    wrappedBuilder.region(region);
     return this;
   }
 
@@ -104,7 +98,7 @@ public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory {
    * @return the builder
    */
   public DynamoDbFeatureStoreBuilder prefix(String prefix) {
-    this.prefix = prefix;
+    wrappedBuilder.prefix(prefix);
     return this;
   }
 
@@ -117,7 +111,7 @@ public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory {
    * @return the builder
    */
   public DynamoDbFeatureStoreBuilder existingClient(DynamoDbClient existingClient) {
-    this.existingClient = existingClient;
+    wrappedBuilder.existingClient(existingClient);
     return this;
   }
   
@@ -130,7 +124,13 @@ public class DynamoDbFeatureStoreBuilder implements FeatureStoreFactory {
    * @return the builder
    */
   public DynamoDbFeatureStoreBuilder caching(FeatureStoreCacheConfig caching) {
-    this.caching = caching;
+    wrappedOuterBuilder.cacheTime(caching.getCacheTime(), caching.getCacheTimeUnit());
+    wrappedOuterBuilder.staleValuesPolicy(caching.getStaleValuesPolicy().toNewEnum());
     return this;
+  }
+
+  @Override
+  public LDValue describeConfiguration(LDConfig config) {
+    return LDValue.of("DynamoDB");
   }
 }

--- a/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbFeatureStoreBuilder.java
+++ b/src/main/java/com/launchdarkly/client/dynamodb/DynamoDbFeatureStoreBuilder.java
@@ -18,7 +18,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 /**
- * Deprecated builder class for the Redis-based persistent data store.
+ * Deprecated builder class for the DynamoDB-based persistent data store.
  * <p>
  * The replacement for this class is {@link com.launchdarkly.client.integrations.DynamoDb}.
  * This class is retained for backward compatibility with older Java SDK versions and will be removed in a

--- a/src/main/java/com/launchdarkly/client/dynamodb/package-info.java
+++ b/src/main/java/com/launchdarkly/client/dynamodb/package-info.java
@@ -1,36 +1,4 @@
 /**
- * This package provides a DynamoDB-backed feature store for the LaunchDarkly Java SDK.
- * <p>
- * For more details about how and why you can use a persistent feature store, see:
- * https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store
- * <p>
- * To use the DynamoDB feature store with the LaunchDarkly client, you will first obtain a
- * builder by calling {@link com.launchdarkly.client.dynamodb.DynamoDbComponents#dynamoDbFeatureStore(String)}, then optionally
- * modify its properties, and then include it in your client configuration. For example:
- * 
- * <pre>
- * import com.launchdarkly.client.*;
- * import com.launchdarkly.client.dynamodb.*;
-
- * DynamoDbFeatureStoreBuilder store = DatabaseComponents.dynamoDbFeatureStore("my-table-name")
- *     .caching(FeatureStoreCacheConfig.enabled().ttlSeconds(30));
- * LDConfig config = new LDConfig.Builder()
- *     .featureStoreFactory(store)
- *     .build();
- * </pre>
- * 
- * Note that the specified table must already exist in DynamoDB. It must have a partition key
- * of "namespace", and a sort key of "key".
- * <p>
- * By default, the feature store uses a basic DynamoDB client configuration that takes its
- * AWS credentials and region from AWS environment variables and/or local configuration files.
- * There are options in the builder for changing some configuration options, or you can
- * configure the DynamoDB client yourself and pass it to the builder with
- * {@link com.launchdarkly.client.dynamodb.DynamoDbFeatureStoreBuilder#existingClient(software.amazon.awssdk.services.dynamodb.DynamoDbClient)}.
- * <p>
- * If you are using the same DynamoDB table as a feature store for multiple LaunchDarkly
- * environments, use the {@link com.launchdarkly.client.dynamodb.DynamoDbFeatureStoreBuilder#prefix(String)}
- * option and choose a different prefix string for each, so they will not interfere with each
- * other's data. 
+ * Deprecated package replaced by {@link com.launchdarkly.client.integrations.DynamoDb}. 
  */
 package com.launchdarkly.client.dynamodb;

--- a/src/main/java/com/launchdarkly/client/integrations/DynamoDb.java
+++ b/src/main/java/com/launchdarkly/client/integrations/DynamoDb.java
@@ -1,0 +1,51 @@
+package com.launchdarkly.client.integrations;
+
+/**
+ * Integration between the LaunchDarkly SDK and DynamoDB.
+ * <p>
+ * This API uses the persistent data store model that was introduced in version 4.12.0 of the LaunchDarkly Java SDK.
+ * If you are using an older Java SDK version, use {@link com.launchdarkly.client.dynamodb.DynamoDbComponents}.
+ *
+ * @since 2.1.0
+ */
+public abstract class DynamoDb {
+  /**
+   * Returns a builder object for creating a DynamoDB-backed data store.
+   * <p>
+   * This object can be modified with {@link DynamoDbDataStoreBuilder} methods for any desired
+   * custom DynamoDB options. Then, pass it to
+   * {@link com.launchdarkly.client.Components#persistentDataStore(com.launchdarkly.client.interfaces.PersistentDataStoreFactory)}
+   * and set any desired caching options. Finally, pass the result to
+   * {@link com.launchdarkly.client.LDConfig.Builder#dataStore(com.launchdarkly.client.FeatureStoreFactory)}.
+   * For example:
+   * 
+   * <pre><code>
+   *     LDConfig config = new LDConfig.Builder()
+   *         .dataStore(
+   *             Components.persistentDataStore(
+   *                 DynamoDb.dataStore("my-table-name")
+   *             ).cacheSeconds(15)
+   *         )
+   *         .build();
+   * </code></pre>
+   * 
+   * Note that the specified table must already exist in DynamoDB. It must have a partition key
+   * of "namespace", and a sort key of "key".
+   * <p>
+   * By default, the data store uses a basic DynamoDB client configuration that takes its
+   * AWS credentials and region from AWS environment variables and/or local configuration files.
+   * There are options in the builder for changing some configuration options, or you can
+   * configure the DynamoDB client yourself and pass it to the builder with
+   * {@link DynamoDbDataStoreBuilder#existingClient(software.amazon.awssdk.services.dynamodb.DynamoDbClient)}.
+   * <p>
+   * If you are using the same DynamoDB table as a feature store for multiple LaunchDarkly
+   * environments, use the {@link DynamoDbDataStoreBuilder#prefix(String)} option and choose a 
+   * different prefix string for each, so they will not interfere with each other's data.
+   *  
+   * @param tableName the table name in DynamoDB (must already exist)
+   * @return a data store configuration object
+   */
+  public static DynamoDbDataStoreBuilder dataStore(String tableName) {
+    return new DynamoDbDataStoreBuilder(tableName);
+  }
+}

--- a/src/main/java/com/launchdarkly/client/integrations/DynamoDbDataStoreBuilder.java
+++ b/src/main/java/com/launchdarkly/client/integrations/DynamoDbDataStoreBuilder.java
@@ -1,0 +1,130 @@
+package com.launchdarkly.client.integrations;
+
+import com.launchdarkly.client.FeatureStoreFactory;
+import com.launchdarkly.client.LDConfig;
+import com.launchdarkly.client.dynamodb.DynamoDbComponents;
+import com.launchdarkly.client.interfaces.DiagnosticDescription;
+import com.launchdarkly.client.interfaces.PersistentDataStoreFactory;
+import com.launchdarkly.client.utils.FeatureStoreCore;
+import com.launchdarkly.client.value.LDValue;
+
+import java.net.URI;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+
+/**
+ * Builder/factory class for the DynamoDB feature store.
+ * <p>
+ * Create this builder by calling {@link DynamoDbComponents#dynamoDbFeatureStore(String)}, then
+ * optionally modify its properties with builder methods, and then include it in your client
+ * configuration with {@link com.launchdarkly.client.LDConfig.Builder#featureStoreFactory(FeatureStoreFactory)}.
+ * <p>
+ * The AWS SDK provides many configuration options for a DynamoDB client. This class has
+ * corresponding methods for some of the most commonly used ones. If you need more sophisticated
+ * control over the DynamoDB client, you can construct one of your own and pass it in with the
+ * {@link #existingClient(DynamoDbClient)} method.
+ * 
+ * @since 2.1.0
+ */
+@SuppressWarnings("deprecation")
+public class DynamoDbDataStoreBuilder implements PersistentDataStoreFactory, DiagnosticDescription {
+  private final String tableName;
+  
+  private String prefix;
+  private DynamoDbClient existingClient;
+  private DynamoDbClientBuilder clientBuilder;
+  
+  DynamoDbDataStoreBuilder(String tableName) {
+    this.tableName = tableName;
+    clientBuilder = DynamoDbClient.builder();
+  }
+  
+  @Override
+  public FeatureStoreCore createPersistentDataStore() {  
+    DynamoDbClient client = (existingClient != null) ? existingClient : clientBuilder.build();
+    return new DynamoDbDataStoreImpl(client, tableName, prefix);
+  }
+  
+  /**
+   * Sets the main AWS client configuration options for the DynamoDB client.
+   * 
+   * @param config an AWS client configuration object
+   * @return the builder
+   */
+  public DynamoDbDataStoreBuilder clientOverrideConfiguration(ClientOverrideConfiguration config) {
+    clientBuilder.overrideConfiguration(config);
+    return this;
+  }
+  
+  /**
+   * Sets the AWS client credentials. If you do not set them programmatically, the AWS SDK will
+   * attempt to find them in environment variables and/or local configuration files.
+   *
+   * @param credentialsProvider a source of credentials
+   * @return the builder
+   */
+  public DynamoDbDataStoreBuilder credentials(AwsCredentialsProvider credentialsProvider) {
+    clientBuilder.credentialsProvider(credentialsProvider);
+    return this;
+  }
+  
+  /**
+   * Sets the service endpoint to use. Normally, you will not use this, as AWS determines the
+   * service endpoint based on your region. However, you can set it explicitly if you are
+   * running your own DynamoDB instance.
+   * 
+   * @param endpointUri the custom endpoint URI
+   * @return the builder
+   */
+  public DynamoDbDataStoreBuilder endpoint(URI endpointUri) {
+    clientBuilder.endpointOverride(endpointUri);
+    return this;
+  }
+  
+  /**
+   * Sets the AWS region to use. If you do not set this, AWS will attempt to determine it from
+   * environment variables and/or local configuration files.
+   * 
+   * @param region the AWS region
+   * @return the builder
+   */
+  public DynamoDbDataStoreBuilder region(Region region) {
+    clientBuilder.region(region);
+    return this;
+  }
+
+  /**
+   * Sets an optional namespace prefix for all keys stored in DynamoDB. Use this if you are sharing
+   * the same database table between multiple clients that are for different LaunchDarkly
+   * environments, to avoid key collisions. 
+   *
+   * @param prefix the namespace prefix
+   * @return the builder
+   */
+  public DynamoDbDataStoreBuilder prefix(String prefix) {
+    this.prefix = prefix;
+    return this;
+  }
+
+  /**
+   * Specifies an existing, already-configured DynamoDB client instance that the feature store
+   * should use rather than creating one of its own. If you specify an existing client, then the
+   * other builder methods for configuring DynamoDB are ignored.
+   *  
+   * @param existingClient an existing DynamoDB client instance
+   * @return the builder
+   */
+  public DynamoDbDataStoreBuilder existingClient(DynamoDbClient existingClient) {
+    this.existingClient = existingClient;
+    return this;
+  }
+
+  @Override
+  public LDValue describeConfiguration(LDConfig config) {
+    return LDValue.of("DynamoDB");
+  }
+}

--- a/src/main/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImpl.java
+++ b/src/main/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImpl.java
@@ -1,4 +1,4 @@
-package com.launchdarkly.client.dynamodb;
+package com.launchdarkly.client.integrations;
 
 import com.google.common.collect.ImmutableMap;
 import com.launchdarkly.client.VersionedData;
@@ -58,8 +58,8 @@ import software.amazon.awssdk.services.dynamodb.paginators.QueryIterable;
  * stored as a single item, this mechanism will not work for extremely large flags or segments.
  * </ul>
  */
-class DynamoDbFeatureStoreCore implements FeatureStoreCore {
-  private static final Logger logger = LoggerFactory.getLogger(DynamoDbFeatureStoreCore.class);
+class DynamoDbDataStoreImpl implements FeatureStoreCore {
+  private static final Logger logger = LoggerFactory.getLogger(DynamoDbDataStoreImpl.class);
   
   static final String partitionKey = "namespace";
   static final String sortKey = "key";
@@ -72,7 +72,7 @@ class DynamoDbFeatureStoreCore implements FeatureStoreCore {
   
   private Runnable updateHook;
   
-  DynamoDbFeatureStoreCore(DynamoDbClient client, String tableName, String prefix) {
+  DynamoDbDataStoreImpl(DynamoDbClient client, String tableName, String prefix) {
     this.client = client;
     this.tableName = tableName;
     this.prefix = "".equals(prefix) ? null : prefix;

--- a/src/main/java/com/launchdarkly/client/integrations/package-info.java
+++ b/src/main/java/com/launchdarkly/client/integrations/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * This package provides a DynamoDB-backed feature store for the LaunchDarkly Java SDK.
+ * <p>
+ * For more details about how and why you can use a persistent data store, see:
+ * https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store
+ * <p>
+ * For details on usage, see {@link com.launchdarkly.client.integrations.DynamoDb}.
+ */
+package com.launchdarkly.client.integrations;

--- a/src/test/java/com/launchdarkly/client/integrations/DeprecatedDynamoDbFeatureStoreTest.java
+++ b/src/test/java/com/launchdarkly/client/integrations/DeprecatedDynamoDbFeatureStoreTest.java
@@ -7,6 +7,8 @@ import com.launchdarkly.client.dynamodb.DynamoDbComponents;
 import com.launchdarkly.client.dynamodb.DynamoDbFeatureStoreBuilder;
 import com.launchdarkly.client.utils.CachingStoreWrapper;
 
+import org.junit.BeforeClass;
+
 import java.net.URI;
 
 import software.amazon.awssdk.regions.Region;
@@ -26,10 +28,13 @@ public class DeprecatedDynamoDbFeatureStoreTest extends FeatureStoreDatabaseTest
   private static final String TABLE_NAME = "LD_DYNAMODB_TEST_TABLE";
   private static final URI DYNAMODB_ENDPOINT = URI.create("http://localhost:8000");
 
+  @BeforeClass
+  public static void setUpAll() {
+    DynamoDbDataStoreImplTest.createTableIfNecessary();
+  }
+  
   public DeprecatedDynamoDbFeatureStoreTest(boolean cached) {
     super(cached);
-    
-    DynamoDbDataStoreImplTest.createTableIfNecessary();
   }
   
   @Override

--- a/src/test/java/com/launchdarkly/client/integrations/DeprecatedDynamoDbFeatureStoreTest.java
+++ b/src/test/java/com/launchdarkly/client/integrations/DeprecatedDynamoDbFeatureStoreTest.java
@@ -1,0 +1,64 @@
+package com.launchdarkly.client.integrations;
+
+import com.launchdarkly.client.FeatureStore;
+import com.launchdarkly.client.FeatureStoreCacheConfig;
+import com.launchdarkly.client.FeatureStoreDatabaseTestBase;
+import com.launchdarkly.client.dynamodb.DynamoDbComponents;
+import com.launchdarkly.client.dynamodb.DynamoDbFeatureStoreBuilder;
+import com.launchdarkly.client.utils.CachingStoreWrapper;
+
+import java.net.URI;
+
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * Runs the standard database feature store test suite that's defined in the Java SDK.
+ * <p>
+ * Note that you must be running a local DynamoDB instance on port 8000 to run these tests.
+ * The simplest way to do this is:
+ * <pre>
+ *     docker run -p 8000:8000 amazon/dynamodb-local
+ * </pre>
+ */
+@SuppressWarnings({ "deprecation", "javadoc" })
+public class DeprecatedDynamoDbFeatureStoreTest extends FeatureStoreDatabaseTestBase<FeatureStore> {
+
+  private static final String TABLE_NAME = "LD_DYNAMODB_TEST_TABLE";
+  private static final URI DYNAMODB_ENDPOINT = URI.create("http://localhost:8000");
+
+  public DeprecatedDynamoDbFeatureStoreTest(boolean cached) {
+    super(cached);
+    
+    DynamoDbDataStoreImplTest.createTableIfNecessary();
+  }
+  
+  @Override
+  protected FeatureStore makeStore() {
+    return baseBuilder().createFeatureStore();
+  }
+  
+  @Override
+  protected FeatureStore makeStoreWithPrefix(String prefix) {
+    return baseBuilder().prefix(prefix).createFeatureStore();
+  }
+  
+  @Override
+  protected void clearAllData() {
+    DynamoDbDataStoreImplTest.clearEverything();
+  }
+  
+  @Override
+  protected boolean setUpdateHook(FeatureStore storeUnderTest, final Runnable hook) {
+    DynamoDbDataStoreImpl core = (DynamoDbDataStoreImpl)((CachingStoreWrapper)storeUnderTest).getCore();
+    core.setUpdateHook(hook);
+    return true;
+  }
+  
+  private DynamoDbFeatureStoreBuilder baseBuilder() {
+    return DynamoDbComponents.dynamoDbFeatureStore(TABLE_NAME)
+        .endpoint(DYNAMODB_ENDPOINT)
+        .region(Region.US_EAST_1)
+        .caching(cached ? FeatureStoreCacheConfig.enabled().ttlSeconds(30) : FeatureStoreCacheConfig.disabled())
+        .credentials(DynamoDbDataStoreImplTest.getTestCredentials());
+  }
+}

--- a/src/test/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImplTest.java
+++ b/src/test/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImplTest.java
@@ -1,18 +1,14 @@
-package com.launchdarkly.client.dynamodb;
+package com.launchdarkly.client.integrations;
 
 import com.google.common.collect.ImmutableMap;
-import com.launchdarkly.client.FeatureStore;
-import com.launchdarkly.client.FeatureStoreCacheConfig;
-import com.launchdarkly.client.FeatureStoreDatabaseTestBase;
-import com.launchdarkly.client.utils.CachingStoreWrapper;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static com.launchdarkly.client.dynamodb.DynamoDbFeatureStoreCore.partitionKey;
-import static com.launchdarkly.client.dynamodb.DynamoDbFeatureStoreCore.sortKey;
+import static com.launchdarkly.client.integrations.DynamoDbDataStoreImpl.partitionKey;
+import static com.launchdarkly.client.integrations.DynamoDbDataStoreImpl.sortKey;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -42,29 +38,28 @@ import software.amazon.awssdk.services.dynamodb.paginators.ScanIterable;
  *     docker run -p 8000:8000 amazon/dynamodb-local
  * </pre>
  */
-public class DynamoDbFeatureStoreTest extends FeatureStoreDatabaseTestBase<FeatureStore> {
-
+@SuppressWarnings("javadoc")
+public class DynamoDbDataStoreImplTest extends PersistentDataStoreTestBase<DynamoDbDataStoreImpl> {
   private static final String TABLE_NAME = "LD_DYNAMODB_TEST_TABLE";
   private static final URI DYNAMODB_ENDPOINT = URI.create("http://localhost:8000");
-
-  public DynamoDbFeatureStoreTest(boolean cached) {
-    super(cached);
-    
-    createTableIfNecessary();
+  
+  @Override
+  protected DynamoDbDataStoreImpl makeStore() {
+    return (DynamoDbDataStoreImpl)DynamoDb.dataStore(TABLE_NAME).createPersistentDataStore();
   }
   
   @Override
-  protected FeatureStore makeStore() {
-    return baseBuilder().createFeatureStore();
-  }
-  
-  @Override
-  protected FeatureStore makeStoreWithPrefix(String prefix) {
-    return baseBuilder().prefix(prefix).createFeatureStore();
+  protected DynamoDbDataStoreImpl makeStoreWithPrefix(String prefix) {
+    return (DynamoDbDataStoreImpl)DynamoDb.dataStore(TABLE_NAME).prefix(prefix).createPersistentDataStore();
   }
   
   @Override
   protected void clearAllData() {
+    clearEverything();
+  }
+  
+  // visible for use by deprecated tests
+  static void clearEverything() {
     DynamoDbClient client = createTestClient();
     
     List<Map<String, AttributeValue>> itemsToDelete = new ArrayList<>();
@@ -82,17 +77,17 @@ public class DynamoDbFeatureStoreTest extends FeatureStoreDatabaseTestBase<Featu
       requests.add(WriteRequest.builder().deleteRequest(builder -> builder.key(item)).build());
     }
     
-    DynamoDbFeatureStoreCore.batchWriteRequests(client, TABLE_NAME, requests);
+    DynamoDbDataStoreImpl.batchWriteRequests(client, TABLE_NAME, requests);
   }
   
   @Override
-  protected boolean setUpdateHook(FeatureStore storeUnderTest, final Runnable hook) {
-    DynamoDbFeatureStoreCore core = (DynamoDbFeatureStoreCore)((CachingStoreWrapper)storeUnderTest).getCore();
-    core.setUpdateHook(hook);
+  protected boolean setUpdateHook(DynamoDbDataStoreImpl storeUnderTest, final Runnable hook) {
+    storeUnderTest.setUpdateHook(hook);
     return true;
   }
   
-  private void createTableIfNecessary() {
+  // visible for use by deprecated tests
+  static void createTableIfNecessary() {
     DynamoDbClient client = createTestClient();
     try {
       client.describeTable(DescribeTableRequest.builder().tableName(TABLE_NAME).build());
@@ -117,15 +112,7 @@ public class DynamoDbFeatureStoreTest extends FeatureStoreDatabaseTestBase<Featu
     client.createTable(request);
   }
   
-  private DynamoDbFeatureStoreBuilder baseBuilder() {
-    return DynamoDbComponents.dynamoDbFeatureStore(TABLE_NAME)
-        .endpoint(DYNAMODB_ENDPOINT)
-        .region(Region.US_EAST_1)
-        .caching(cached ? FeatureStoreCacheConfig.enabled().ttlSeconds(30) : FeatureStoreCacheConfig.disabled())
-        .credentials(getTestCredentials());
-  }
-  
-  private DynamoDbClient createTestClient() {
+  static DynamoDbClient createTestClient() {
     return DynamoDbClient.builder()
         .endpointOverride(DYNAMODB_ENDPOINT)
         .region(Region.US_EAST_1)
@@ -133,7 +120,7 @@ public class DynamoDbFeatureStoreTest extends FeatureStoreDatabaseTestBase<Featu
         .build();
   }
   
-  private AwsCredentialsProvider getTestCredentials() {
+  static AwsCredentialsProvider getTestCredentials() {
     // The values here don't matter, it just expects us to provide something (since there may not be AWS
     // environment variables or config files where the tests are running)
     return StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret"));

--- a/src/test/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImplTest.java
+++ b/src/test/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImplTest.java
@@ -45,12 +45,12 @@ public class DynamoDbDataStoreImplTest extends PersistentDataStoreTestBase<Dynam
   
   @Override
   protected DynamoDbDataStoreImpl makeStore() {
-    return (DynamoDbDataStoreImpl)DynamoDb.dataStore(TABLE_NAME).createPersistentDataStore();
+    return (DynamoDbDataStoreImpl)baseBuilder().createPersistentDataStore();
   }
   
   @Override
   protected DynamoDbDataStoreImpl makeStoreWithPrefix(String prefix) {
-    return (DynamoDbDataStoreImpl)DynamoDb.dataStore(TABLE_NAME).prefix(prefix).createPersistentDataStore();
+    return (DynamoDbDataStoreImpl)baseBuilder().prefix(prefix).createPersistentDataStore();
   }
   
   @Override

--- a/src/test/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImplTest.java
+++ b/src/test/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImplTest.java
@@ -86,6 +86,13 @@ public class DynamoDbDataStoreImplTest extends PersistentDataStoreTestBase<Dynam
     return true;
   }
   
+  static DynamoDbDataStoreBuilder baseBuilder() {
+    return DynamoDb.dataStore(TABLE_NAME)
+        .endpoint(DYNAMODB_ENDPOINT)
+        .region(Region.US_EAST_1)
+        .credentials(DynamoDbDataStoreImplTest.getTestCredentials());
+  }
+  
   // visible for use by deprecated tests
   static void createTableIfNecessary() {
     DynamoDbClient client = createTestClient();

--- a/src/test/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImplTest.java
+++ b/src/test/java/com/launchdarkly/client/integrations/DynamoDbDataStoreImplTest.java
@@ -2,6 +2,8 @@ package com.launchdarkly.client.integrations;
 
 import com.google.common.collect.ImmutableMap;
 
+import org.junit.BeforeClass;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +44,11 @@ import software.amazon.awssdk.services.dynamodb.paginators.ScanIterable;
 public class DynamoDbDataStoreImplTest extends PersistentDataStoreTestBase<DynamoDbDataStoreImpl> {
   private static final String TABLE_NAME = "LD_DYNAMODB_TEST_TABLE";
   private static final URI DYNAMODB_ENDPOINT = URI.create("http://localhost:8000");
+  
+  @BeforeClass
+  public static void setUpAll() {
+    createTableIfNecessary();
+  }
   
   @Override
   protected DynamoDbDataStoreImpl makeStore() {


### PR DESCRIPTION
This adds a `DynamoDb.dataStore()` builder that conforms to the newer persistent data store semantics in the upcoming Java SDK 4.12.0 release.

The older methods for use with older Java SDK versions are retained, but deprecated. The old `DynamoDbFeatureStoreBuilder` now just delegates to the new `DynamoDbDataStoreBuilder`, which is the same approach we've used for the older Redis APIs in the SDK.

This is using a 4.12.0-SNAPSHOT version of the SDK; the dependency will be updated after releasing the SDK and before releasing this package.